### PR TITLE
Updates tempdir to be created with a unique salt, and always be removed.

### DIFF
--- a/package.go
+++ b/package.go
@@ -25,7 +25,14 @@ func buildBinary(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	tempBootstrap := os.TempDir() + "/bootstrap"
+	tempBootstrap, err := os.MkdirTemp("", "bootstrap")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tempBootstrap)
+
+	tempBootstrap = tempBootstrap + "/bootstrap"
+
 	//go build -tags lambda.norpc -o bootstrap main.go
 	cmd := exec.Command("go", "build", "-tags", "lambda.norpc", "-o", tempBootstrap, path)
 	out, err := cmd.CombinedOutput()
@@ -38,7 +45,7 @@ func buildBinary(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	_ = os.Remove(tempBootstrap)
+
 	return data, nil
 }
 


### PR DESCRIPTION
The tempdir was being created unconditionally in the root of TMPDIR. Calling os.MkdirTemp (which replaces ioutil.TempDir) lets the stdlib inject a unique salt for the new directory's name, so repeated invocations of the tool won't overwrite old invocations.

I also moved the deletion of the tempdir into a deferred statement. I get that this is a matter of taste in this case, but I figured if someone doesn't have teh `go` cli tool in $PATH, you don't necessarily want the temp dir to hang around.