### PR TITLE
Restore cross-compilation for Lambda packaging

### DIFF
--- a/package.go
+++ b/package.go
@@ -57,7 +57,7 @@ func PackageTo(path string, output io.Writer) error {
 	}
 
 	cmd = exec.Command("go", "mod", "tidy")
-	envs = append(envs, "GOMODCACHE="+GOMODCACHE, "GOCACHE="+GOCACHE)
+	envs = append(envs, "GOMODCACHE="+GOMODCACHE, "GOCACHE="+GOCACHE, "GOOS=linux", "GOARCH=arm64", "CGO_ENABLED=0")
 	cmd.Env = envs
 	cmd.Dir = tmpDir
 	out, err = cmd.CombinedOutput()


### PR DESCRIPTION
PR #20 removed the GOOS and GOARCH flags from the build step in package.go. This means PackageTo builds for the host platform instead of Linux ARM64, producing binaries that fail with exit code 126 when deployed to Lambda.

Restores GOOS=linux GOARCH=arm64 CGO_ENABLED=0 on the build environment.