### PR TITLE
Add environment variable interpolation for TOML config

### DIFF
--- a/project.go
+++ b/project.go
@@ -4,11 +4,14 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 )
+
+var envRefPattern = regexp.MustCompile(`\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 
 // ProjectConfig represents the top-level structure of a glambda.toml file.
 // It defines a project name that groups lambdas together, and the set of
@@ -51,7 +54,9 @@ func LoadConfig(path string) (ProjectConfig, error) {
 }
 
 // ParseConfig parses TOML content into a ProjectConfig, performing
-// validation on the result.
+// validation and environment variable resolution on the result.
+// Values wrapped in ${VAR} are resolved from the process environment.
+// Unset or empty environment variables are a hard error.
 func ParseConfig(content string) (ProjectConfig, error) {
 	var config ProjectConfig
 	_, err := toml.Decode(content, &config)
@@ -62,7 +67,42 @@ func ParseConfig(content string) (ProjectConfig, error) {
 	if err != nil {
 		return ProjectConfig{}, err
 	}
+	err = resolveEnvironmentRefs(&config)
+	if err != nil {
+		return ProjectConfig{}, err
+	}
 	return config, nil
+}
+
+// resolveEnvironmentRefs walks all environment values across all lambda
+// definitions and replaces ${VAR} references with the corresponding
+// process environment variable. Returns an error if any referenced
+// variable is unset or empty.
+func resolveEnvironmentRefs(config *ProjectConfig) error {
+	for i := range config.Lambda {
+		for key, val := range config.Lambda[i].Environment {
+			resolved, err := resolveString(val, config.Lambda[i].Name, key)
+			if err != nil {
+				return err
+			}
+			config.Lambda[i].Environment[key] = resolved
+		}
+	}
+	return nil
+}
+
+func resolveString(val, lambdaName, key string) (string, error) {
+	var resolveErr error
+	resolved := envRefPattern.ReplaceAllStringFunc(val, func(match string) string {
+		envVar := envRefPattern.FindStringSubmatch(match)[1]
+		envVal, ok := os.LookupEnv(envVar)
+		if !ok || envVal == "" {
+			resolveErr = fmt.Errorf("lambda %q environment key %q: references ${%s} but it is not set", lambdaName, key, envVar)
+			return match
+		}
+		return envVal
+	})
+	return resolved, resolveErr
 }
 
 func validateConfig(config ProjectConfig) error {

--- a/project_test.go
+++ b/project_test.go
@@ -3,6 +3,7 @@ package glambda_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mr-joshcrane/glambda"
@@ -252,5 +253,94 @@ func TestToDeployOptions_MinimalFields(t *testing.T) {
 	opts := def.ToDeployOptions()
 	if len(opts) != 0 {
 		t.Errorf("expected 0 deploy options for minimal config, got %d", len(opts))
+	}
+}
+
+func TestParseConfig_ResolvesEnvVarReferences(t *testing.T) {
+	t.Setenv("TEST_SECRET_KEY", "super-secret-value")
+	config, err := glambda.ParseConfig(`
+[project]
+name = "my-service"
+
+[[lambda]]
+name = "test"
+handler = "./main.go"
+
+[lambda.environment]
+API_KEY = "${TEST_SECRET_KEY}"
+STATIC_VAL = "plaintext"
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := config.Lambda[0].Environment
+	if env["API_KEY"] != "super-secret-value" {
+		t.Errorf("expected resolved value 'super-secret-value', got %q", env["API_KEY"])
+	}
+	if env["STATIC_VAL"] != "plaintext" {
+		t.Errorf("expected static value 'plaintext', got %q", env["STATIC_VAL"])
+	}
+}
+
+func TestParseConfig_FailsOnMissingEnvVar(t *testing.T) {
+	_, err := glambda.ParseConfig(`
+[project]
+name = "my-service"
+
+[[lambda]]
+name = "test"
+handler = "./main.go"
+
+[lambda.environment]
+SECRET = "${DEFINITELY_NOT_SET_ANYWHERE}"
+`)
+	if err == nil {
+		t.Fatal("expected error for unset env var reference")
+	}
+	if !strings.Contains(err.Error(), "DEFINITELY_NOT_SET_ANYWHERE") {
+		t.Errorf("expected error to mention the missing var, got: %s", err)
+	}
+	if !strings.Contains(err.Error(), "not set") {
+		t.Errorf("expected error to say 'not set', got: %s", err)
+	}
+}
+
+func TestParseConfig_FailsOnEmptyEnvVar(t *testing.T) {
+	t.Setenv("EMPTY_SECRET", "")
+	_, err := glambda.ParseConfig(`
+[project]
+name = "my-service"
+
+[[lambda]]
+name = "test"
+handler = "./main.go"
+
+[lambda.environment]
+SECRET = "${EMPTY_SECRET}"
+`)
+	if err == nil {
+		t.Fatal("expected error for empty env var")
+	}
+}
+
+func TestParseConfig_MultiplerefsInOneValue(t *testing.T) {
+	t.Setenv("HOST", "db.example.com")
+	t.Setenv("PORT", "5432")
+	config, err := glambda.ParseConfig(`
+[project]
+name = "my-service"
+
+[[lambda]]
+name = "test"
+handler = "./main.go"
+
+[lambda.environment]
+DB_URL = "${HOST}:${PORT}"
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Lambda[0].Environment["DB_URL"] != "db.example.com:5432" {
+		t.Errorf("expected 'db.example.com:5432', got %q", config.Lambda[0].Environment["DB_URL"])
 	}
 }


### PR DESCRIPTION
## Summary

- Environment values in `glambda.toml` can now reference process environment variables using `${VAR}` syntax
- Resolution happens after TOML parsing as a preflight check — unset or empty variables fail the deploy before any AWS calls
- Plain string values are never touched — only explicit `${...}` references are resolved
- Multiple references in a single value are supported (e.g. `"${HOST}:${PORT}"`)

## Example

```toml
[lambda.environment]
SLACK_API_KEY = "${SLACK_API_KEY}"    # resolved from process env
TABLE_NAME = "VulnerabilityManagement" # left as-is
DB_URL = "${DB_HOST}:${DB_PORT}"       # multiple refs supported
```

## Security

- `${VAR}` pattern is explicit opt-in — you can't accidentally resolve env vars
- Unset or empty env vars are a hard error, not a silent empty string
- TOML is parsed into Go structs first, then interpolation runs on string values only — no injection of new TOML structure is possible
- Plan output does not print environment values, so secrets don't leak to logs

## Tests

- Happy path: `${VAR}` resolved, plain strings untouched
- Missing env var: hard error with descriptive message
- Empty env var: hard error
- Multiple refs in one value: both resolved