### PR TITLE
Always redeploy lambdas on apply

### DIFF
--- a/glambda.go
+++ b/glambda.go
@@ -341,20 +341,19 @@ func PrepareLambdaAction(l Lambda, c LambdaClient) (LambdaAction, error) {
 		return nil, err
 	}
 
-	var action LambdaAction
-	if exists {
-		currentFunc, err := c.GetFunction(context.Background(), &lambda.GetFunctionInput{
-			FunctionName: aws.String(l.Name),
-		})
-		if err != nil {
-			return nil, err
-		}
-		mergedConfig := MergeConfiguration(currentFunc.Configuration, l.Config)
-		action = NewLambdaUpdateAction(c, l, pkg.Bytes(), mergedConfig)
-	} else {
-		action = NewLambdaCreateAction(c, l, pkg.Bytes())
+	if !exists {
+		return NewLambdaCreateAction(c, l, pkg.Bytes()), nil
 	}
-	return action, nil
+
+	currentFunc, err := c.GetFunction(context.Background(), &lambda.GetFunctionInput{
+		FunctionName: aws.String(l.Name),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	mergedConfig := MergeConfiguration(currentFunc.Configuration, l.Config)
+	return NewLambdaUpdateAction(c, l, pkg.Bytes(), mergedConfig), nil
 }
 
 // CreateLambdaCommand is a paperwork reducer that translates parameters into

--- a/plan.go
+++ b/plan.go
@@ -80,7 +80,7 @@ func ComputePlan(cfg ProjectConfig, client LambdaClient) (Plan, error) {
 
 	// Check each desired lambda against remote state
 	for _, def := range cfg.Lambda {
-		r, exists := remoteByName[def.Name]
+		_, exists := remoteByName[def.Name]
 		if !exists {
 			plan.Items = append(plan.Items, PlanItem{
 				Action:     PlanCreate,
@@ -88,15 +88,11 @@ func ComputePlan(cfg ProjectConfig, client LambdaClient) (Plan, error) {
 				Reason:     "not found in AWS",
 				Definition: &def,
 			})
-			continue
-		}
-		// Exists — check if config hash differs
-		desiredHash := ConfigHash(def)
-		if r.configHash != desiredHash {
+		} else {
 			plan.Items = append(plan.Items, PlanItem{
 				Action:     PlanUpdate,
 				Name:       def.Name,
-				Reason:     "config changed",
+				Reason:     "deploy",
 				Definition: &def,
 			})
 		}

--- a/plan_test.go
+++ b/plan_test.go
@@ -106,7 +106,7 @@ func TestComputePlan_DetectsConfigChange(t *testing.T) {
 	}
 }
 
-func TestComputePlan_NoChangesWhenHashMatches(t *testing.T) {
+func TestComputePlan_AlwaysGeneratesUpdateForExistingLambdas(t *testing.T) {
 	t.Parallel()
 	def := glambda.LambdaDefinition{Name: "myFunc", Handler: "./main.go", Timeout: 30}
 	currentHash := glambda.ConfigHash(def)
@@ -131,8 +131,12 @@ func TestComputePlan_NoChangesWhenHashMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.HasChanges() {
-		t.Error("expected no changes when hash matches")
+	if !plan.HasChanges() {
+		t.Error("expected plan to always generate UPDATE for existing lambdas")
+	}
+	creates, updates, deletes := plan.Summary()
+	if creates != 0 || updates != 1 || deletes != 0 {
+		t.Errorf("expected 0 creates, 1 update, 0 deletes — got %d/%d/%d", creates, updates, deletes)
 	}
 }
 


### PR DESCRIPTION
## Summary

Removes the config-hash-only skip logic from `ComputePlan`. Previously, if the TOML config hash matched the deployed `GlambdaConfigHash` tag, the lambda was skipped entirely — even if the handler code had changed.

Now `apply` always builds and deploys every lambda in the TOML. The plan always generates UPDATE for existing lambdas.

## Why

Go builds are not reproducible — comparing a locally built zip against the deployed `CodeSha256` doesn't work because the same source produces different binaries across builds. Hashing source files only catches changes to `main.go` but misses dependency changes. The config hash only catches TOML changes.

The simplest correct behavior: always deploy. Lambda deploys take seconds, and in CI there's always something that changed.

## What changed

- `plan.go`: `ComputePlan` always generates UPDATE for existing lambdas (CREATE for new, DELETE for orphans — unchanged)
- `glambda.go`: `PrepareLambdaAction` reverted to its original simple form (build → create or update)
- `plan_test.go`: Updated test to expect UPDATE instead of no-op when config hash matches